### PR TITLE
commands.go: Permissions Values

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -20,7 +20,7 @@ const (
 	// MaxPlatformConfigurationRegister is the maximum number of PCRs
 	MaxPlatformConfigurationRegister = 24
 	// DefaultFilePermissions is the default write permission
-	DefaultFilePermissions = 660
+	DefaultFilePermissions = 0660
 	// LinuxEFIFirmwareDir is the UEFI linux firmware directory
 	LinuxEFIFirmwareDir = "/sys/firmware/efi"
 	// Delay is used for sealing operations delay
@@ -56,7 +56,7 @@ func Ek() error {
 	}
 
 	if *ekCommandOutfile != "" {
-		if err := ioutil.WriteFile(*ekCommandOutfile, pubEk, 660); err != nil {
+		if err := ioutil.WriteFile(*ekCommandOutfile, pubEk, DefaultFilePermissions); err != nil {
 			return err
 		}
 	}
@@ -120,7 +120,7 @@ func CryptoSeal() error {
 		return err
 	}
 
-	return ioutil.WriteFile(*cryptoCommandSealCipherFile, sealed, 660)
+	return ioutil.WriteFile(*cryptoCommandSealCipherFile, sealed, DefaultFilePermissions)
 }
 
 // CryptoUnseal unseals data by the TPM against PCR
@@ -138,7 +138,7 @@ func CryptoUnseal() error {
 		return err
 	}
 
-	return ioutil.WriteFile(*cryptoCommandUnsealPlainFile, unsealed, 660)
+	return ioutil.WriteFile(*cryptoCommandUnsealPlainFile, unsealed, DefaultFilePermissions)
 }
 
 // CryptoReseal reseals a data by given sealing configuration
@@ -166,7 +166,7 @@ func CryptoReseal() error {
 		return err
 	}
 
-	return ioutil.WriteFile(*cryptoCommandResealKeyfile, sealed, 660)
+	return ioutil.WriteFile(*cryptoCommandResealKeyfile, sealed, DefaultFilePermissions)
 }
 
 // PcrList dumps all PCRs
@@ -235,7 +235,7 @@ func DiskFormat() error {
 		return err
 	}
 
-	if err = ioutil.WriteFile(keystorePath+"/plain", randBytes, 660); err != nil {
+	if err = ioutil.WriteFile(keystorePath+"/plain", randBytes, DefaultFilePermissions); err != nil {
 		return err
 	}
 
@@ -253,7 +253,7 @@ func DiskFormat() error {
 		return err
 	}
 
-	return ioutil.WriteFile(*diskCommandFormatFile, sealed, 660)
+	return ioutil.WriteFile(*diskCommandFormatFile, sealed, DefaultFilePermissions)
 }
 
 // DiskOpen opens a LUKS device
@@ -281,7 +281,7 @@ func DiskOpen() error {
 		return err
 	}
 
-	if err = ioutil.WriteFile(keystorePath+"/plain", sealed, 660); err != nil {
+	if err = ioutil.WriteFile(keystorePath+"/plain", sealed, DefaultFilePermissions); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Go uses 4-digit octal file permissions, not three. This fixes the `660` permissions in `commands.go` to evaulate to `0660` instead of `01224`.

The previously-unused constant `DefaultFilePermissions` is now used throughout.