### PR TITLE
travis.yml: Deprecate Old Go Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: go
 sudo: false
 
 go:
-  - "1.8"
-  - "1.9"
-  - "1.10"
+  - "1.11"
+  - "1.12"
+  - "1.13"
   - tip
 
 before_install:


### PR DESCRIPTION
`.travis.yml` is currently configured to test against relatively ancient versions of Go.

Update to test against 1.11-tip.