### PR TITLE
pkg/tpm/structures: fix GUID struct

### DIFF
--- a/pkg/tpm/structures.go
+++ b/pkg/tpm/structures.go
@@ -14,7 +14,7 @@ type EFIGuid struct {
 	blockA uint32
 	blockB uint16
 	blockC uint16
-	blockD uint16
+	blockD [2]uint8
 	blockE [6]uint8
 }
 


### PR DESCRIPTION
blockD is two bytes, big endian

Signed-off-by: Daniel Maslowski <info@orangecms.org>
